### PR TITLE
Check to see if url has url variables

### DIFF
--- a/Google Shopping Api V2/app/code/community/Weboffice/GoogleShoppingApi/Model/Attribute/Link.php
+++ b/Google Shopping Api V2/app/code/community/Weboffice/GoogleShoppingApi/Model/Attribute/Link.php
@@ -38,6 +38,10 @@ class Weboffice_GoogleShoppingApi_Model_Attribute_Link extends Weboffice_GoogleS
                 }
             }
             
+            if(strpos($url, "?") !== true) {
+                $url .= "?";
+            }
+            
             $shoppingProduct->setLink($url.'&utm_source=GoogleShopping');
         }
 


### PR DESCRIPTION
My shop didn't have url variables, so when this was added to the URL: $shoppingProduct->setLink($url.'&utm_source=GoogleShopping'); it created an invalid url (http://www.myshop/cateogry/product.html&utm_source=GoogleShopping)  

I've added a check to see if the url has a "?" and appending it if missing.
