### PR TITLE
Fix for when getProduct() returns null

### DIFF
--- a/Magento Display Shipping estimation Block in Product view page/app/code/community/WebDevlopers/ProductPageShipping/Block/Estimate/Abstract.php
+++ b/Magento Display Shipping estimation Block in Product view page/app/code/community/WebDevlopers/ProductPageShipping/Block/Estimate/Abstract.php
@@ -48,6 +48,6 @@ abstract class WebDevlopers_ProductPageShipping_Block_Estimate_Abstract extends 
    
     public function isEnabled()
     {
-        return $this->getConfig()->isEnabled() && !$this->getProduct()->isVirtual();
+        return $this->getConfig()->isEnabled() && $this->getProduct() && !$this->getProduct()->isVirtual();
     }
 }


### PR DESCRIPTION
Fix for when `$this->getProduct()` doesn't resolve to a product model, perhaps from being used outside of the regular Magento product context and the product doesn't exist in the registry.

Harmless change for regular use, I figure it can't hurt to add it.

Reference: http://stackoverflow.com/questions/37298990/fatal-error-call-to-a-member-function-isvirtual-on-a-non-object
